### PR TITLE
Add async support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.62.0]
+        rust: [stable, 1.75.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+- Implemented async support in addition to default sync support.
+
+### Changed
+- Raised MSRV to 1.75.0
+
 ## [1.0.1] - 2025-03-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,20 @@ include = [
     "/LICENSE-APACHE",
 ]
 
+[features]
+default = []
+async = ["dep:embedded-hal-async"]
+
 [dependencies]
 embedded-hal = "1.0"
+embedded-hal-async = { version = "1.0", optional = true }
+maybe-async-cfg = "0.2.5"
 nb = "1.1"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
-embedded-hal-mock = {version = "0.11.1", default-features = false, features = ["eh1"]}
+embedded-hal-mock = {version = "0.11.1", default-features = false, features = ["eh1", "embedded-hal-async"]}
+tokio = { version = "1.44.2", features = ["rt", "macros"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/tmp1x2.svg)](https://crates.io/crates/tmp1x2)
 [![Docs](https://docs.rs/tmp1x2/badge.svg)](https://docs.rs/tmp1x2)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.62+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.75+-blue.svg)
 [![Build Status](https://github.com/eldruin/tmp1x2-rs/workflows/Build/badge.svg)](https://github.com/eldruin/tmp1x2-rs/actions?query=workflow%3ABuild)
 [![Coverage Status](https://coveralls.io/repos/github/eldruin/tmp1x2-rs/badge.svg?branch=master)](https://coveralls.io/github/eldruin/tmp1x2-rs?branch=master)
 
@@ -68,6 +68,9 @@ fn main() {
     println!("Temperature: {:.1}ºC", temperature);
 }
 ```
+
+Additionally, async support can be enabled via the `async` feature. For example:  
+`cargo build --features async`
 
 ## Support
 

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -1,10 +1,13 @@
-use linux_embedded_hal::I2cdev;
-use tmp1x2::{SlaveAddr, Tmp1x2};
-
+#[cfg(not(feature = "async"))]
 fn main() {
-    let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let address = SlaveAddr::default();
-    let mut sensor = Tmp1x2::new(dev, address);
+    let dev = linux_embedded_hal::I2cdev::new("/dev/i2c-1").unwrap();
+    let address = tmp1x2::SlaveAddr::default();
+    let mut sensor = tmp1x2::Tmp1x2::new(dev, address);
     let temperature = sensor.read_temperature().unwrap();
     println!("Temperature: {:.1}ºC", temperature);
+}
+
+#[cfg(feature = "async")]
+fn main() {
+    panic!("Feature `async` must NOT be enabled to run this example.");
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -5,18 +5,31 @@ use crate::{
     ConversionRate as CR, Error, FaultQueue, ModeChangeError, Register, ThermostatMode, Tmp1x2,
 };
 use core::marker::PhantomData;
-use embedded_hal::i2c;
+#[cfg(not(feature = "async"))]
+use embedded_hal::i2c::I2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 impl<I2C, E> Tmp1x2<I2C, mode::Continuous>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
     /// Change into one-shot conversion mode (shutdown).
     ///
     /// If the mode change failed you will get a `ModeChangeError`.
     /// You can get the unchanged device back from it.
-    pub fn into_one_shot(mut self) -> Result<Tmp1x2<I2C, mode::OneShot>, ModeChangeError<E, Self>> {
-        if let Err(Error::I2C(e)) = self.config_one_shot() {
+    pub async fn into_one_shot(
+        mut self,
+    ) -> Result<Tmp1x2<I2C, mode::OneShot>, ModeChangeError<E, Self>> {
+        if let Err(Error::I2C(e)) = self.config_one_shot().await {
             return Err(ModeChangeError::I2C(e, self));
         }
         Ok(Tmp1x2 {
@@ -29,18 +42,26 @@ where
     }
 }
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 impl<I2C, E> Tmp1x2<I2C, mode::OneShot>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
     /// Change into continuous conversion mode.
     ///
     /// If the mode change failed you will get a `ModeChangeError`.
     /// You can get the unchanged device back from it.
-    pub fn into_continuous(
+    pub async fn into_continuous(
         mut self,
     ) -> Result<Tmp1x2<I2C, mode::Continuous>, ModeChangeError<E, Self>> {
-        if let Err(Error::I2C(e)) = self.config_continuous() {
+        if let Err(Error::I2C(e)) = self.config_continuous().await {
             return Err(ModeChangeError::I2C(e, self));
         }
         Ok(Tmp1x2 {
@@ -52,59 +73,84 @@ where
         })
     }
 
-    pub(crate) fn trigger_one_shot_measurement(&mut self) -> Result<(), Error<E>> {
+    pub(crate) async fn trigger_one_shot_measurement(&mut self) -> Result<(), Error<E>> {
         // This bit is not stored
         self.write_register(Register::CONFIG, self.config.with_high_msb(BFH::ONE_SHOT))
+            .await
     }
 }
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 impl<I2C, E, MODE> Tmp1x2<I2C, MODE>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
-    fn config_continuous(&mut self) -> Result<(), Error<E>> {
+    async fn config_continuous(&mut self) -> Result<(), Error<E>> {
         self.write_config(self.config.with_low_msb(BFH::SHUTDOWN))
+            .await
     }
 
-    fn config_one_shot(&mut self) -> Result<(), Error<E>> {
+    async fn config_one_shot(&mut self) -> Result<(), Error<E>> {
         self.write_config(self.config.with_high_msb(BFH::SHUTDOWN))
+            .await
     }
 
     /// Enable the extended measurement mode.
     ///
     /// This allows measurement of temperatures above 128°C.
-    pub fn enable_extended_mode(&mut self) -> Result<(), Error<E>> {
+    pub async fn enable_extended_mode(&mut self) -> Result<(), Error<E>> {
         self.write_config(self.config.with_high_lsb(BFL::EXTENDED_MODE))
+            .await
     }
 
     /// Disable the extended measurement mode.
     ///
     /// This puts the device in normal measurement mode. It will not measure
     /// temperatures above 128°C.
-    pub fn disable_extended_mode(&mut self) -> Result<(), Error<E>> {
+    pub async fn disable_extended_mode(&mut self) -> Result<(), Error<E>> {
         self.write_config(self.config.with_low_lsb(BFL::EXTENDED_MODE))
+            .await
     }
 
     /// Set the conversion rate when in continuous conversion mode.
-    pub fn set_conversion_rate(&mut self, rate: CR) -> Result<(), Error<E>> {
+    pub async fn set_conversion_rate(&mut self, rate: CR) -> Result<(), Error<E>> {
         let Config { lsb, msb } = self.config;
         match rate {
-            CR::_0_25Hz => self.write_config(Config {
-                lsb: lsb & !BFL::CONV_RATE1 & !BFL::CONV_RATE0,
-                msb,
-            }),
-            CR::_1Hz => self.write_config(Config {
-                lsb: lsb & !BFL::CONV_RATE1 | BFL::CONV_RATE0,
-                msb,
-            }),
-            CR::_4Hz => self.write_config(Config {
-                lsb: lsb | BFL::CONV_RATE1 & !BFL::CONV_RATE0,
-                msb,
-            }),
-            CR::_8Hz => self.write_config(Config {
-                lsb: lsb | BFL::CONV_RATE1 | BFL::CONV_RATE0,
-                msb,
-            }),
+            CR::_0_25Hz => {
+                self.write_config(Config {
+                    lsb: lsb & !BFL::CONV_RATE1 & !BFL::CONV_RATE0,
+                    msb,
+                })
+                .await
+            }
+            CR::_1Hz => {
+                self.write_config(Config {
+                    lsb: lsb & !BFL::CONV_RATE1 | BFL::CONV_RATE0,
+                    msb,
+                })
+                .await
+            }
+            CR::_4Hz => {
+                self.write_config(Config {
+                    lsb: lsb | BFL::CONV_RATE1 & !BFL::CONV_RATE0,
+                    msb,
+                })
+                .await
+            }
+            CR::_8Hz => {
+                self.write_config(Config {
+                    lsb: lsb | BFL::CONV_RATE1 | BFL::CONV_RATE0,
+                    msb,
+                })
+                .await
+            }
         }
     }
 
@@ -113,8 +159,12 @@ where
     /// The value provided will be capped to be in the interval
     /// `[-128.0, 127.9375]` in normal mode and `[-256.0, 255.875]` in
     /// extended mode.
-    pub fn set_high_temperature_threshold(&mut self, temperature: f32) -> Result<(), Error<E>> {
+    pub async fn set_high_temperature_threshold(
+        &mut self,
+        temperature: f32,
+    ) -> Result<(), Error<E>> {
         self.set_temperature_threshold(temperature, Register::T_HIGH)
+            .await
     }
 
     /// Set the low temperature threshold.
@@ -122,11 +172,15 @@ where
     /// The value provided will be capped to be in the interval
     /// `[-128.0, 127.9375]` in normal mode and `[-256.0, 255.875]` in
     /// extended mode.
-    pub fn set_low_temperature_threshold(&mut self, temperature: f32) -> Result<(), Error<E>> {
+    pub async fn set_low_temperature_threshold(
+        &mut self,
+        temperature: f32,
+    ) -> Result<(), Error<E>> {
         self.set_temperature_threshold(temperature, Register::T_LOW)
+            .await
     }
 
-    fn set_temperature_threshold(
+    async fn set_temperature_threshold(
         &mut self,
         temperature: f32,
         register: u8,
@@ -134,57 +188,75 @@ where
         if (self.config.lsb & BFL::EXTENDED_MODE) != 0 {
             let (msb, lsb) = convert_temp_to_register_extended(temperature);
             self.write_register(register, RegisterU16 { lsb, msb })
+                .await
         } else {
             let (msb, lsb) = convert_temp_to_register_normal(temperature);
             self.write_register(register, RegisterU16 { lsb, msb })
+                .await
         }
     }
 
     /// Set the fault queue.
     ///
     /// Set the number of consecutive faults that will trigger an alert.
-    pub fn set_fault_queue(&mut self, fq: FaultQueue) -> Result<(), Error<E>> {
+    pub async fn set_fault_queue(&mut self, fq: FaultQueue) -> Result<(), Error<E>> {
         let Config { lsb, msb } = self.config;
         match fq {
-            FaultQueue::_1 => self.write_config(Config {
-                lsb,
-                msb: msb & !BFH::FAULT_QUEUE1 & !BFH::FAULT_QUEUE0,
-            }),
-            FaultQueue::_2 => self.write_config(Config {
-                lsb,
-                msb: msb & !BFH::FAULT_QUEUE1 | BFH::FAULT_QUEUE0,
-            }),
-            FaultQueue::_4 => self.write_config(Config {
-                lsb,
-                msb: msb | BFH::FAULT_QUEUE1 & !BFH::FAULT_QUEUE0,
-            }),
-            FaultQueue::_6 => self.write_config(Config {
-                lsb,
-                msb: msb | BFH::FAULT_QUEUE1 | BFH::FAULT_QUEUE0,
-            }),
+            FaultQueue::_1 => {
+                self.write_config(Config {
+                    lsb,
+                    msb: msb & !BFH::FAULT_QUEUE1 & !BFH::FAULT_QUEUE0,
+                })
+                .await
+            }
+            FaultQueue::_2 => {
+                self.write_config(Config {
+                    lsb,
+                    msb: msb & !BFH::FAULT_QUEUE1 | BFH::FAULT_QUEUE0,
+                })
+                .await
+            }
+            FaultQueue::_4 => {
+                self.write_config(Config {
+                    lsb,
+                    msb: msb | BFH::FAULT_QUEUE1 & !BFH::FAULT_QUEUE0,
+                })
+                .await
+            }
+            FaultQueue::_6 => {
+                self.write_config(Config {
+                    lsb,
+                    msb: msb | BFH::FAULT_QUEUE1 | BFH::FAULT_QUEUE0,
+                })
+                .await
+            }
         }
     }
 
     /// Set the alert polarity.
-    pub fn set_alert_polarity(&mut self, polarity: AlertPolarity) -> Result<(), Error<E>> {
+    pub async fn set_alert_polarity(&mut self, polarity: AlertPolarity) -> Result<(), Error<E>> {
         match polarity {
             AlertPolarity::ActiveLow => {
                 self.write_config(self.config.with_low_msb(BFH::ALERT_POLARITY))
+                    .await
             }
             AlertPolarity::ActiveHigh => {
                 self.write_config(self.config.with_high_msb(BFH::ALERT_POLARITY))
+                    .await
             }
         }
     }
 
     /// Set the thermostat mode.
-    pub fn set_thermostat_mode(&mut self, mode: ThermostatMode) -> Result<(), Error<E>> {
+    pub async fn set_thermostat_mode(&mut self, mode: ThermostatMode) -> Result<(), Error<E>> {
         match mode {
             ThermostatMode::Comparator => {
                 self.write_config(self.config.with_low_msb(BFH::THERMOSTAT))
+                    .await
             }
             ThermostatMode::Interrupt => {
                 self.write_config(self.config.with_high_msb(BFH::THERMOSTAT))
+                    .await
             }
         }
     }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,31 +1,47 @@
 use crate::RegisterU16;
 use crate::{Config, Error, Register, Tmp1x2};
-use embedded_hal::i2c;
+#[cfg(not(feature = "async"))]
+use embedded_hal::i2c::I2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 impl<I2C, E, MODE> Tmp1x2<I2C, MODE>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
-    pub(crate) fn write_config(&mut self, data: Config) -> Result<(), Error<E>> {
-        self.write_register(Register::CONFIG, data.clone())?;
+    pub(crate) async fn write_config(&mut self, data: Config) -> Result<(), Error<E>> {
+        self.write_register(Register::CONFIG, data.clone()).await?;
         self.config = data;
         Ok(())
     }
 
-    pub(crate) fn write_register(
+    pub(crate) async fn write_register(
         &mut self,
         register: u8,
         data: RegisterU16,
     ) -> Result<(), Error<E>> {
         self.i2c
             .write(self.address, &[register, data.msb, data.lsb])
+            .await
             .map_err(Error::I2C)
     }
 
-    pub(crate) fn read_register_u16(&mut self, register: u8) -> Result<RegisterU16, Error<E>> {
+    pub(crate) async fn read_register_u16(
+        &mut self,
+        register: u8,
+    ) -> Result<RegisterU16, Error<E>> {
         let mut data = [0; 2];
         self.i2c
             .write_read(self.address, &[register], &mut data)
+            .await
             .map_err(Error::I2C)?;
         Ok(RegisterU16 {
             msb: data[0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@
 //! ### Read temperature in continuous mode
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr};
 //!
@@ -65,11 +67,14 @@
 //! let mut sensor = Tmp1x2::new(dev, address);
 //! let temperature = sensor.read_temperature().unwrap();
 //! println!("Temperature: {}", temperature);
+//! # }
 //! ```
 //!
 //! ### Provide an alternative address
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr};
 //!
@@ -77,11 +82,14 @@
 //! let (a1, a0) = (false, true);
 //! let address = SlaveAddr::Alternative(a1, a0);
 //! let mut sensor = Tmp1x2::new(dev, address);
+//! # }
 //! ```
 //!
 //! ### Change into one-shot mode and trigger a measurement
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use nb::block;
 //! use tmp1x2::{Tmp1x2, SlaveAddr};
@@ -90,11 +98,14 @@
 //! let sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! let mut sensor = sensor.into_one_shot().ok().expect("Mode change error");
 //! let temperature = block!(sensor.read_temperature());
+//! # }
 //! ```
 //!
 //! ### Get the device back if there was an error during a mode change
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{ModeChangeError, Tmp1x2, SlaveAddr};
 //!
@@ -108,33 +119,42 @@
 //! } else {
 //!     unreachable!();
 //! }
+//! # }
 //! ```
 //!
 //! ### Enable the extended measurement mode
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! sensor.enable_extended_mode().unwrap();
+//! # }
 //! ```
 //!
 //! ### Set the conversion rate to 1Hz
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr, ConversionRate};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! sensor.set_conversion_rate(ConversionRate::_1Hz).unwrap();
+//! # }
 //! ```
 //!
 //! ### Set the high and low temperature thresholds
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr, ConversionRate};
 //!
@@ -142,6 +162,7 @@
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! sensor.set_low_temperature_threshold(-15.0).unwrap();
 //! sensor.set_high_temperature_threshold(60.0).unwrap();
+//! # }
 //! ```
 //!
 //! ### Set the fault queue
@@ -149,34 +170,43 @@
 //! This sets the number of consecutive faults that will trigger an alert.
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr, FaultQueue};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! sensor.set_fault_queue(FaultQueue::_4).unwrap();
+//! # }
 //! ```
 //!
 //! ### Set the alert polarity
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{ Tmp1x2, SlaveAddr, AlertPolarity };
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! sensor.set_alert_polarity(AlertPolarity::ActiveHigh).unwrap();
+//! # }
 //! ```
 //!
 //! ### Set the thermostat mode
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{ Tmp1x2, SlaveAddr, ThermostatMode };
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! sensor.set_thermostat_mode(ThermostatMode::Interrupt).unwrap();
+//! # }
 //! ```
 //!
 //! ### Check whether an alert is active as defined by the comparator mode
@@ -185,12 +215,15 @@
 //! the status as defined by the comparator mode.
 //!
 //! ```no_run
+//! # #[cfg(not(feature = "async"))]
+//! # {
 //! use linux_embedded_hal::I2cdev;
 //! use tmp1x2::{Tmp1x2, SlaveAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let mut sensor = Tmp1x2::new(dev, SlaveAddr::default());
 //! let alert = sensor.is_comparator_mode_alert_active().unwrap();
+//! # }
 //! ```
 
 #![deny(unsafe_code)]
@@ -198,7 +231,10 @@
 #![no_std]
 
 use core::marker::PhantomData;
-use embedded_hal::i2c;
+#[cfg(not(feature = "async"))]
+use embedded_hal::i2c::I2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
 pub use nb;
 
 /// Possible errors in this crate
@@ -387,8 +423,16 @@ pub mod marker {
 }
 
 /// TMP1X2 device driver.
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 #[derive(Debug, Default)]
-pub struct Tmp1x2<I2C, MODE> {
+pub struct Tmp1x2<I2C: AsyncI2c, MODE> {
     /// The concrete I²C device implementation.
     i2c: I2C,
     /// The I²C device address.
@@ -400,9 +444,17 @@ pub struct Tmp1x2<I2C, MODE> {
     _mode: PhantomData<MODE>,
 }
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 impl<I2C, E> Tmp1x2<I2C, marker::mode::Continuous>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
     /// Create new instance of the TMP102 or TMP112x device.
     ///
@@ -418,7 +470,18 @@ where
     }
 }
 
-impl<I2C, MODE> Tmp1x2<I2C, MODE> {
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Tmp1x2",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
+impl<I2C, E, MODE> Tmp1x2<I2C, MODE>
+where
+    I2C: AsyncI2c<Error = E>,
+{
     /// Destroy driver instance, return I²C bus instance.
     pub fn destroy(self) -> I2C {
         self.i2c

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -16,30 +16,39 @@ fn get_write_expectation(register: u8, lsb: u8, msb: u8) -> [I2cTransaction; 1] 
 
 macro_rules! config_test {
     ($name:ident, $method:ident, $expected_lsb:expr, $expected_msb:expr) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async")), test),
+            async(feature = "async", tokio::test)
+        )]
+        async fn $name() {
             let expectations =
                 get_write_expectation(Register::CONFIG, $expected_lsb, $expected_msb);
             let mut dev = setup(&expectations);
-            dev.$method().unwrap();
+            dev.$method().await.unwrap();
             dev.destroy().done();
         }
     };
 }
 
-#[test]
-fn can_change_into_one_shot() {
+#[maybe_async_cfg::maybe(
+    sync(cfg(not(feature = "async")), test),
+    async(feature = "async", tokio::test)
+)]
+async fn can_change_into_one_shot() {
     let expectations = [I2cTransaction::write(
         DEVICE_ADDRESS,
         vec![Register::CONFIG, DEFAULT_MSB | 1, DEFAULT_LSB],
     )];
     let dev = setup(&expectations);
-    let dev = dev.into_one_shot().unwrap();
+    let dev = dev.into_one_shot().await.unwrap();
     dev.destroy().done();
 }
 
-#[test]
-fn can_change_into_continuous() {
+#[maybe_async_cfg::maybe(
+    sync(cfg(not(feature = "async")), test),
+    async(feature = "async", tokio::test)
+)]
+async fn can_change_into_continuous() {
     let expectations = [
         I2cTransaction::write(
             DEVICE_ADDRESS,
@@ -51,8 +60,8 @@ fn can_change_into_continuous() {
         ),
     ];
     let dev = setup(&expectations);
-    let dev = dev.into_one_shot().unwrap();
-    let dev = dev.into_continuous().unwrap();
+    let dev = dev.into_one_shot().await.unwrap();
+    let dev = dev.into_continuous().await.unwrap();
     dev.destroy().done();
 }
 
@@ -71,12 +80,15 @@ config_test!(
 
 macro_rules! config_value_test {
     ($name:ident, $method:ident, $value:expr, $expected_lsb:expr, $expected_msb:expr) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async")), test),
+            async(feature = "async", tokio::test)
+        )]
+        async fn $name() {
             let expectations =
                 get_write_expectation(Register::CONFIG, $expected_lsb, $expected_msb);
             let mut dev = setup(&expectations);
-            dev.$method($value).unwrap();
+            dev.$method($value).await.unwrap();
             dev.destroy().done();
         }
     };
@@ -172,11 +184,14 @@ config_value_test!(
 
 macro_rules! set_value_test {
     ($name:ident, $method:ident, $value:expr, $register:expr, $expected_lsb:expr, $expected_msb:expr) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async")), test),
+            async(feature = "async", tokio::test)
+        )]
+        async fn $name() {
             let expectations = get_write_expectation($register, $expected_lsb, $expected_msb);
             let mut dev = setup(&expectations);
-            dev.$method($value).unwrap();
+            dev.$method($value).await.unwrap();
             dev.destroy().done();
         }
     };
@@ -216,8 +231,11 @@ set_value_test!(
     0b0111_1111
 );
 
-#[test]
-fn can_set_extended_high_temp_threshold() {
+#[maybe_async_cfg::maybe(
+    sync(cfg(not(feature = "async")), test),
+    async(feature = "async", tokio::test)
+)]
+async fn can_set_extended_high_temp_threshold() {
     let expectations = [
         I2cTransaction::write(
             DEVICE_ADDRESS,
@@ -233,7 +251,7 @@ fn can_set_extended_high_temp_threshold() {
         ),
     ];
     let mut dev = setup(&expectations);
-    dev.enable_extended_mode().unwrap();
-    dev.set_high_temperature_threshold(255.875).unwrap();
+    dev.enable_extended_mode().await.unwrap();
+    dev.set_high_temperature_threshold(255.875).await.unwrap();
     dev.destroy().done();
 }


### PR DESCRIPTION
This PR introduces async support to the driver while still preserving sync functionality via the `maybe-async` crate. The sync version can be built via:

`cargo build --features is_sync`

And the async version is built by default. Tests were also updated to support async via the `tokio` async runtime.

`linux-embedded-hal` does not currently seem to support async so the linux example will panic without the `is_sync` feature enabled.